### PR TITLE
Fix Google Analytics conversion tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,17 +97,7 @@
   gtag('config', 'AW-17214175569');
 </script>
 
-	  <!-- Event snippet for Submit lead form (2) conversion page -->
-<script>
-  // Function to track MyHealthStory purchase conversion
-  function trackMyHealthStoryPurchase() {
-    gtag('event', 'conversion', {
-      'send_to': 'AW-17214175569/sEzbCKPf2e0aENHyrZBA',
-      'value': 1.0,
-      'currency': 'CHF'
-    });
-  }
-</script>
+<!-- The incorrect event snippet that was here should now be GONE -->
 
 <!-- Cloudflare Web Analytics -->
 <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "e8b5c8e8b5c8e8b5c8e8b5c8e8b5c8e8"}'></script>

--- a/success.html
+++ b/success.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Thank You for Your Purchase</title>
+    
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6CNLJJJ8WQ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-6CNLJJJ8WQ');
+      gtag('config', 'AW-17214175569');
+    </script>
+    
+</head>
+<body>
+    <h1>Thank You!</h1>
+    <p>Your purchase is complete. Your download will be sent to your email shortly.</p>
+    
+    <!-- Event snippet for MyHealthStory purchase conversion page -->
+    <script>
+      gtag('event', 'conversion', {
+        'send_to': 'AW-17214175569/sEzbCKPf2e0aENHyrZBA',
+        'value': 1.0,
+        'currency': 'CHF'
+      });
+    </script>
+    
+</body>
+</html>
+


### PR DESCRIPTION
- Create success.html thank you page for post-purchase redirect
- Move conversion tracking event snippet from index.html to success.html
- Remove incorrect event snippet from main page (lines 100-110)
- PayPal buttons already correctly configured to redirect to /success
- Conversion tracking will now fire only after successful purchase completion